### PR TITLE
fix:修复副标题包含“多国语(言)”时错误识别为了国语音轨

### DIFF
--- a/auto_feed.user.js
+++ b/auto_feed.user.js
@@ -2224,7 +2224,7 @@ String.prototype.get_label = function(){
     if (my_string.match(/([简繁].{0,12}字幕|[简繁中].{0,3}字|DIY.{1,5}字|内封.{0,3}[繁中字])|(Text.*?#\d+[\s\S]*?Chinese|subtitles.*chs|subtitles.*mandarin|subtitle.*chinese)/i)){
         labels.zz = true;
     }
-    if (my_string.match(/(国.{0,3}语|国.{0,3}配|台.{0,3}语|台.{0,3}配)|(Audio.*Chinese|Audio.*mandarin)/i)){
+    if (my_string.match(/([^多]国.{0,3}语|国.{0,3}配|台.{0,3}语|台.{0,3}配)|(Audio.*Chinese|Audio.*mandarin)/i)){
         labels.gy = true;
     }
     if (my_string.match(/(粤.{0,3}语|粤.{0,3}配|Audio.*cantonese)/i)){


### PR DESCRIPTION
修复副标题包含“多国语(言)”时错误识别为了国语音轨