### PR TITLE
Load icon from wsrv.nl first

### DIFF
--- a/auto_feed.user.js
+++ b/auto_feed.user.js
@@ -11473,7 +11473,11 @@ function auto_feed() {
                 else{
                     img_url = used_site_info[key].url + 'favicon.ico';
                 }
-                para.innerHTML = '<div style="display:inline-block"><img src='+ img_url+ ' class="round_icon" style="display:inline-block">' + ' ' + key + '</div>';
+ 
+                img_url_wsrv = 'https://wsrv.nl/?url=' + img_url
+                para.innerHTML = '<div style="display:inline-block"><img src="' + img_url_wsrv +
+                                 '"onerror="this.onerror=null; this.src=' + "'" + img_url + "'" +
+                                 '"class="round_icon" style="display:inline-block">' + key + '</div>'
             }
         }
 


### PR DESCRIPTION
https://github.com/tomorrow505/auto_feed_js/issues/50

图片加载先尝试 wsrv.nl 失败后回退

before
![](https://i.imgur.com/L8GbYcG.png)
after
![](https://i.imgur.com/7KUTneA.png)

主要是连接数少了

其实影响也不大，只是约莫 80% 的浏览并不是为了转种，可以节省掉这部份的多余网络连接