### PR TITLE
增加申请访问其他网站的权限

### DIFF
--- a/auto_feed.user.js
+++ b/auto_feed.user.js
@@ -4,6 +4,7 @@
 // @thanks       感谢宝大、86大佬、贝壳等大佬提供邀请码;感谢宝大、86大佬提供友情赞助;感谢86大佬、手大、kmeng、黑白、甘蔗等大佬赠予PTP积分.
 // @contributor  daoshuailx/hollips/kmeng/wyyqyl/shmt86/sauterne
 // @description  PT一键转种脚本
+// @connect *
 // @match        https://blutopia.cc/torrents?imdb=tt*
 // @namespace    https://greasyfork.org/zh-CN/scripts/424132-auto-feed
 // @updateURL    https://greasyfork.org/zh-CN/scripts/424132-auto-feed


### PR DESCRIPTION
添加这行代码后只需要点击允许所有网站, 就不会跳出跨域请求的界面了, 之前转载每个站都要同意一次
@connect

This tag defines the domains (no top-level domains) including subdomains which are allowed to be retrieved by GM_xmlhttpRequest

// @connect <value>

<value> can be:

    a domain name like example.com (this will also allow all subdomains).
    a subdomain name like subdomain.example.com.
    self to whitelist the domain the script is currently running at.
    localhost to access the localhost.
    an IP address like 1.2.3.4.
    *.

If it's not possible to declare all domains a userscript might connect to then it's a good practice to do the following:

    Declare all known or at least all common domains that might be connected by the script to avoid the confirmation dialog for most users.
    Additionally add @connect * to the script to allow Tampermonkey to offer an "Always allow all domains" button.

Users can also whitelist all requests by adding * to the user domain whitelist at the script settings tab.

Notes:

    Both, the initial and the final URL will be checked!
    For backward compatibility to Scriptish @domain tags are interpreted as well.
    Multiple tag instances are allowed.

More examples:

// @connect tmnk.net
// @connect www.tampermonkey.net
// @connect self
// @connect localhost
// @connect 8.8.8.8
// @connect *
