### PR TITLE
use decodeURIComponent to decode url.hash before decodeURI

### DIFF
--- a/auto_feed.user.js
+++ b/auto_feed.user.js
@@ -148,7 +148,13 @@
     20240526：适配新架构站点YemaPT(by lorentz)。
 */
 
-var site_url = decodeURI(location.href);
+function decodeSiteURL() {
+    var url = new URL(location.href);
+    url.hash = decodeURIComponent(url.hash);
+    return decodeURI(url.toString())
+}
+
+var site_url = decodeSiteURL();
 const TIMEOUT = 6000;
 const N = "\n";
 var evt = document.createEvent("HTMLEvents");


### PR DESCRIPTION
在decode转种URI的时候有个小问题，当在源站跳转的时候，`location.href`形如`https://[目标站点]/upload.php#separator#[base64]`是没问题的，但是在地址栏转种地址已经变成了`https://[目标站点]/upload.php#separator%23[base64]`，这是如果把这个地址复制到另外一个tab，转种自动填充就不起作用了，因为这时`location.href`变成了`https://[目标站点]/upload.php#separator%23[base64]`，而`decodeURI`并不会把hash里的`%23`转成#，这个PR就是利用`decodeURIComponent`处理这个`%23`，这样后续的site_url.match就不会有问题了