### PR TITLE
fix ubits codec

### DIFF
--- a/auto_feed.user.js
+++ b/auto_feed.user.js
@@ -22766,8 +22766,8 @@ function auto_feed() {
                 case 'H265': codec_box.val(7); break;
                 case 'H264': codec_box.val(1); break;
                 case 'VC-1': codec_box.val(2); break;
-                case 'X265': codec_box.val(8); break;
-                case 'X264': codec_box.val(6); break;
+                case 'X265': codec_box.val(7); break;
+                case 'X264': codec_box.val(1); break;
                 case 'MPEG-2': codec_box.val(4); break;
                 case 'XVID': codec_box.val(3);
             }


### PR DESCRIPTION
ubits视频编码没有8和6了, 会导致选不上