### PR TITLE
修复 YemaPT 转种表单填充并添加 www1 域名支持

### DIFF
--- a/auto_feed.user.js
+++ b/auto_feed.user.js
@@ -4900,12 +4900,25 @@ async function selectDropdownOption(tid, index, targetTitle) {
     var clickEvent = document.createEvent ('MouseEvents');
     clickEvent.initEvent ('mousedown', true, true);
     document.getElementById(tid).dispatchEvent(clickEvent);
-    await new Promise(resolve => setTimeout(resolve, 100));
-    const listHolder = document.querySelectorAll('.rc-virtual-list-holder')[index];
+    
+    // 等待下拉列表出现，带重试机制
+    let listHolder = null;
+    const maxRetries = 10;
+    const retryDelay = 200;
+    for (let i = 0; i < maxRetries; i++) {
+        await new Promise(resolve => setTimeout(resolve, retryDelay));
+        listHolder = document.querySelectorAll('.rc-virtual-list-holder')[index];
+        if (listHolder) {
+            break;
+        }
+        console.log(`等待下拉列表渲染... (${i + 1}/${maxRetries})`);
+    }
+    
     if (!listHolder) {
         console.error("未找到下拉列表，请确保下拉框已经打开！");
         return;
     }
+    
     const findAndClick = () => {
         const option = listHolder.querySelector(`.ant-select-item-option[title="${targetTitle}"]`);
         if (option) {
@@ -17270,7 +17283,64 @@ function auto_feed() {
 
         else if (forward_site == 'YemaPT') {
             delete Array.prototype.remove;
-            var type_code = '未分类';
+            
+            // 监听 yemapt 的表单准备完毕事件，只通过该事件触发一次数据填充
+            var yemaPTFormReadyHandler = function(e) {
+                console.log('YemaPT form ready via torrentAddPageReady event, detail:', e);
+                processYemaPTForm();
+            };
+            
+            window.addEventListener('torrentAddPageReady', yemaPTFormReadyHandler, { once: true });
+            
+            function processYemaPTForm() {
+                const ant_form = document.querySelector('form.ant-form')
+                const __reactFiber = getReactFiberNode(ant_form);
+                const instance = getReactComponentInstance(__reactFiber);
+                if (instance) ant_form_instance = instance;
+                instance?.context?.setFieldsValue({ 'showName': raw_info.name });
+                instance?.context?.setFieldsValue({ 'shortDesc': raw_info.small_descr });
+                try {
+                    const cover_img = raw_info.descr?.split('[/img]')?.at(0).split('[img]')?.at(1).trim();
+                    instance?.context?.setFieldsValue({ 'picture': cover_img });
+                } catch (err) {}
+
+                setTimeout(function(){
+                    addTorrent(raw_info.torrent_url, raw_info.torrent_name, forward_site, null);
+                }, 200);
+
+                function bbcode2markdown(text) {
+                    text = text.replace(/\[size=\d\]/ig, '').replace(/\[\/size\]/ig, '');
+                    text = text.replace(/\[font=.+?\]/ig, '').replace(/\[\/font\]/ig, '');
+                    text = text.replace(/\[color=.+?\]/ig, '').replace(/\[\/color\]/ig, '');
+                    text = text.replace(/\[img\](.*?)\[\/img\]/ig, '![_]($1)');
+                    text = text.replace(/\[b\]\s*/ig, '**').replace(/\s*\[\/b\]/ig, '**');
+                    text = text.replace(/\[i\]\s*/ig, '*').replace(/\s*\[\/i\]/ig, '*');
+                    text = text.replace(/\[url=([^\]]*?)\](.*?)\[\/url\]/ig, '[$2]($1)');
+                    text = text.replace(/\[quote\](.*?)\[\/quote\]/isg, (m, n) => '> '+ n.split('\n').join('\n> ')+'\n\n');
+                    return text;
+                }
+                instance?.context?.setFieldsValue({ 'longDesc': bbcode2markdown(raw_info.descr) });
+                $('#longDesc').css({'height': '800px'});
+
+                // 匿名
+                if (if_uplver) {
+                    $('input[class="ant-radio-input"][value="y"]').click();
+                }
+
+                if (raw_info.dburl) {
+                    try{
+                        const dbid = raw_info.dburl.match(/subject\/(\d+)/)[1];
+                        instance?.context?.setFieldsValue({ 'douban': dbid });
+                    } catch (err) {}
+                }
+                if (raw_info.url) {
+                    try{
+                        const imdbid = raw_info.url.match(/title\/tt(\d+)/)[1];
+                        instance?.context?.setFieldsValue({ 'imdb': imdbid });
+                    } catch (err) {}
+                }
+                
+                var type_code = '未分类';
             switch (raw_info.type){
                 case '电影': case '剧集': case '综艺': case '动漫': case '体育': case '短剧': case '软件': case '游戏': case '书籍': case '音乐':
                     type_code = raw_info.type; break;
@@ -17390,56 +17460,8 @@ function auto_feed() {
                     console.error("执行过程中出错:", error);
                 }
             }
-
-            $('#shortDesc').wait(function(){
-                const ant_form = document.querySelector('form.ant-form')
-                const __reactFiber = getReactFiberNode(ant_form);
-                const instance = getReactComponentInstance(__reactFiber);
-                if (instance) ant_form_instance = instance;
-                instance?.context?.setFieldsValue({ 'showName': raw_info.name });
-                instance?.context?.setFieldsValue({ 'shortDesc': raw_info.small_descr });
-                try {
-                    const cover_img = raw_info.descr?.split('[/img]')?.at(0).split('[img]')?.at(1).trim();
-                    instance?.context?.setFieldsValue({ 'picture': cover_img });
-                } catch (err) {}
-
-                setTimeout(function(){
-                    addTorrent(raw_info.torrent_url, raw_info.torrent_name, forward_site, null);
-                }, 200);
-
-                function bbcode2markdown(text) {
-                    text = text.replace(/\[size=\d\]/ig, '').replace(/\[\/size\]/ig, '');
-                    text = text.replace(/\[font=.+?\]/ig, '').replace(/\[\/font\]/ig, '');
-                    text = text.replace(/\[color=.+?\]/ig, '').replace(/\[\/color\]/ig, '');
-                    text = text.replace(/\[img\](.*?)\[\/img\]/ig, '![_]($1)');
-                    text = text.replace(/\[b\]\s*/ig, '**').replace(/\s*\[\/b\]/ig, '**');
-                    text = text.replace(/\[i\]\s*/ig, '*').replace(/\s*\[\/i\]/ig, '*');
-                    text = text.replace(/\[url=([^\]]*?)\](.*?)\[\/url\]/ig, '[$2]($1)');
-                    text = text.replace(/\[quote\](.*?)\[\/quote\]/isg, (m, n) => '> '+ n.split('\n').join('\n> ')+'\n\n');
-                    return text;
-                }
-                instance?.context?.setFieldsValue({ 'longDesc': bbcode2markdown(raw_info.descr) });
-                $('#longDesc').css({'height': '800px'});
-
-                // 匿名
-                if (if_uplver) {
-                    $('input[class="ant-radio-input"][value="y"]').click();
-                }
-
-                if (raw_info.dburl) {
-                    try{
-                        const dbid = raw_info.dburl.match(/subject\/(\d+)/)[1];
-                        instance?.context?.setFieldsValue({ 'douban': dbid });
-                    } catch (err) {}
-                }
-                if (raw_info.url) {
-                    try{
-                        const imdbid = raw_info.url.match(/title\/tt(\d+)/)[1];
-                        instance?.context?.setFieldsValue({ 'imdb': imdbid });
-                    } catch (err) {}
-                }
-                runSequence(medium_code, standard_code, videoCodec, audioCodec, source_code, team_code, tags, type_code);
-            }, 1000/*次*/, 200/*毫秒/次*/);
+            runSequence(medium_code, standard_code, videoCodec, audioCodec, source_code, team_code, tags, type_code);
+            }
         }
 
         else if (forward_site == 'TTG'){

--- a/auto_feed.user.js
+++ b/auto_feed.user.js
@@ -70,6 +70,7 @@
 // @match        http*://cinemaz.to/torrent/*
 // @match        https://zhuque.in/torrent/*
 // @match        https://www.yemapt.org/*
+// @match        https://www1.yemapt.org/*
 // @match        https://beyond-hd.me/download_check/*
 // @match        http*://passthepopcorn.me/torrents.php?id*
 // @match        http*://*php?id=*&torrentid=*
@@ -284,7 +285,7 @@ if (site_url.match(/^.{3,30}userdetail/i) && !site_url.match(/bluebird-hd/)) {
     return;
 }
 
-if (site_url.match(/^https:\/\/www.yemapt.org/) && !site_url.match(/add\?/)) {
+if (site_url.match(/^https:\/\/www1?.yemapt.org/) && !site_url.match(/add\?/)) {
     return;
 }
 
@@ -1045,7 +1046,7 @@ const default_site_info = {
     'ICC': {'url': 'https://www.icc2022.com/', 'enable': 1},
     'CyanBug': {'url': 'https://cyanbug.net/', 'enable': 1},
     'ZHUQUE': {'url': 'https://zhuque.in/', 'enable': 1},
-    'YemaPT': {'url': 'https://www.yemapt.org/', 'enable': 1},
+    'YemaPT': {'url': 'https://www1?.yemapt.org/', 'enable': 1},
     '海棠': {'url': 'https://www.htpt.cc/', 'enable': 1},
     '杏林': {'url': 'https://xingtan.one/', 'enable': 1},
     'UBits': {'url': 'https://ubits.club/', 'enable': 1},
@@ -1392,7 +1393,7 @@ const o_site_info = {
     'DTR': 'https://torrent.desi/',
     'HONE': 'https://hawke.uno/',
     'ZHUQUE': 'https://zhuque.in/',
-    'YemaPT': 'https://www.yemapt.org/',
+    'YemaPT': 'https://www1?.yemapt.org/',
     'SpeedApp': 'https://speedapp.io/',
     'MTeam': used_site_info.MTeam.url,
     'ReelFliX': 'https://reelflix.cc/',
@@ -2218,7 +2219,7 @@ function judge_if_the_site_as_source() {
     if (site_url.match(/^https:\/\/.*open.cd\/plugin_upload.php#separator#/i)) {
         return 0;
     }
-    if (site_url.match(/^https:\/\/www.yemapt.org\/#\/torrent\/add\?/i)) {
+    if (site_url.match(/^https:\/\/www1?.yemapt.org\/#\/torrent\/add\?/i)) {
         return 0;
     }
     if (site_url.match(/^https?:\/\/(avistaz|privatehd|cinemaz).to\/upload\/torrent\/\d+/i)) {
@@ -2329,7 +2330,7 @@ function judge_if_the_site_in_domestic() {
         if (key != 'FRDS' && key != 'BYR' && key != 'U2'){
             domain = o_site_info[key].split('//')[1].replace('/', '');
             reg = new RegExp(domain, 'i');
-            if (site_url.split('#separator#')[0].match(reg) || site_url.match(/https:\/\/www.yemapt.org\/#\/torrent\/add\?/)){
+            if (site_url.split('#separator#')[0].match(reg) || site_url.match(/https:\/\/www1?.yemapt.org\/#\/torrent\/add\?/)){
                 return 0;
             }
         }


### PR DESCRIPTION
- 将 YemaPT 转种页面的表单填充逻辑改为监听 `torrentAddPageReady` 事件，替代原有的元素轮询方式，确保在后端数据就绪后再填充表单
- 为 `selectDropdownOption` 函数添加重试机制，解决 Ant Design 虚拟下拉列表异步渲染导致的选项找不到问题
- 新增对 `www1.yemapt.org` 域名的支持，与原有 `www.yemapt.org` 并存
- 使用 `{ once: true }` 事件监听器选项确保表单填充仅执行一次

### 具体修改
- 移除 `$('#shortDesc').wait()` 备用逻辑，改为仅通过 `torrentAddPageReady` 事件触发
- 下拉选项选择增加重试循环（最多10次，每次间隔200ms），等待 `.rc-virtual-list-holder` 渲染完成
- 更新所有 `@match`、URL配置和正则表达式，同时支持 `www.yemapt.org` 和 `www1.yemapt.org`