### PR TITLE
修复 HHClub 转 YemaPT 时海报进入介绍的问题

### DIFF
--- a/auto_feed.user.js
+++ b/auto_feed.user.js
@@ -1576,6 +1576,7 @@ var raw_info = {
     'url': '', //imdb链接
     'dburl': '', //豆瓣链接
     'descr': '', //简介
+    'poster': '', //海报
     'log_info': '',  //音乐特有
     'tracklist': '', //音乐特有
     'music_type': '', //音乐特有
@@ -3128,6 +3129,7 @@ function fill_raw_info(raw_info, forward_site){
     raw_info.small_descr = raw_info.small_descr || '';
     raw_info.descr = raw_info.descr || '';
     raw_info.full_mediainfo = raw_info.full_mediainfo || '';
+    raw_info.poster = raw_info.poster || '';
     raw_info.tracklist = raw_info.tracklist || '';
     raw_info.log_info = raw_info.log_info || '';
     raw_info.edition_info = raw_info.edition_info || '';
@@ -9544,6 +9546,10 @@ function auto_feed() {
             insert_row = tbody.insertRow(0);
             douban_box = tbody.insertRow(0);
             try {
+                var cover = $('#cover-content').attr('src') || $('#cover-content').attr('data-src');
+                if (cover) {
+                    raw_info.poster = cover;
+                }
                 if ($('div:contains(其他信息):last').length) {
                     var div_descr = $('div:contains(其他信息):last').parent().next()[0];
                     raw_info.descr = walkDOM(div_descr.cloneNode(true)).trim();
@@ -9562,7 +9568,7 @@ function auto_feed() {
             } catch (err) {}
             try {
                 var screen = $('#screenshot-content')[0];
-                raw_info.descr = '\n' + walkDOM(screen.cloneNode(true));
+                raw_info.descr = (raw_info.descr ? raw_info.descr + '\n\n' : '') + walkDOM(screen.cloneNode(true)).trim();
             } catch (err) {}
             try {
                 raw_info.url = match_link('imdb', $('#kimdb').html());
@@ -17380,9 +17386,12 @@ function auto_feed() {
                 ant_form_instance = torrentForm;
                 torrentForm?.setFieldsValue({ 'showName': raw_info.name });
                 torrentForm?.setFieldsValue({ 'shortDesc': raw_info.small_descr });
+                var yemaPTCoverImg = '';
                 try {
-                    const cover_img = raw_info.descr?.split('[/img]')?.at(0).split('[img]')?.at(1).trim();
-                    torrentForm?.setFieldsValue({ 'picture': cover_img });
+                    yemaPTCoverImg = raw_info.poster || raw_info.descr?.split('[/img]')?.at(0).split('[img]')?.at(1).trim();
+                    if (yemaPTCoverImg) {
+                        torrentForm?.setFieldsValue({ 'picture': yemaPTCoverImg });
+                    }
                 } catch (err) {}
 
                 setTimeout(function(){
@@ -17406,6 +17415,10 @@ function auto_feed() {
 
                 function removeMediaInfoFromDescr(text) {
                     var cleaned = text || '';
+                    if (yemaPTCoverImg) {
+                        const escapedPoster = yemaPTCoverImg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+                        cleaned = cleaned.replace(new RegExp(`^\\s*(?:\\[url=[^\\]]+\\])?\\[img\\]${escapedPoster}\\[\\/img\\](?:\\[\\/url\\])?\\s*`, 'i'), '');
+                    }
                     if (yemaPTMediaInfo.length > 20 && yemaPTMediaInfo.match(/DISC INFO|\.MPLS|Video Codec|Disc Label|General|RELEASE\.NAME|RELEASE DATE|Unique ID|RESOLUTiON|Bitrate|帧　率|音频码率|视频码率/i)) {
                         const normalizeMediaInfo = function(value) {
                             return value.replace(/\[\/?(quote|code|font|size|color).*?\]/ig, '').replace(/\s+/g, ' ').trim();


### PR DESCRIPTION
## 变更内容

  - HHClub 抓取封面时改为写入独立的 `poster` 字段，不再拼进 `descr`
  - 修复 HHClub 截图抓取时覆盖已有介绍的问题，改为追加截图内容
  - YemaPT 填表时优先使用 `raw_info.poster` 填充海报字段
  - YemaPT 写入长介绍前会移除开头海报，避免海报重复出现在介绍中

  ## 验证

  - `node --check auto_feed.user.js`
  - `git diff --check`