### PR TITLE
支持 YemaPT 填充截图列表

### DIFF
--- a/auto_feed.user.js
+++ b/auto_feed.user.js
@@ -17412,12 +17412,32 @@ function auto_feed() {
                 const yemaPTInfos = get_mediainfo_picture_from_descr(raw_info.descr || '');
                 var yemaPTMediaInfo = raw_info.full_mediainfo || raw_info.multi_mediainfo || yemaPTInfos.mediainfo || '';
                 yemaPTMediaInfo = yemaPTMediaInfo.replace(/\[\/?(quote|code|font|size|color).*?\]/ig, '').trim();
+                function fillYemaPTScreenshotList() {
+                    get_full_size_picture_urls(null, yemaPTInfos.pic_info, $('#not'), false, function(img_info) {
+                        var screenshotList = img_info.split(/\n+/).map(function(item) {
+                            return item.trim();
+                        }).filter(function(item) {
+                            return item;
+                        });
+                        screenshotList = Array.from(new Set(screenshotList));
+                        if (screenshotList.length > 0) {
+                            torrentForm?.setFieldsValue({ 'screenshotList': screenshotList });
+                        }
+                    });
+                }
 
                 function removeMediaInfoFromDescr(text) {
                     var cleaned = text || '';
                     if (yemaPTCoverImg) {
                         const escapedPoster = yemaPTCoverImg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
                         cleaned = cleaned.replace(new RegExp(`^\\s*(?:\\[url=[^\\]]+\\])?\\[img\\]${escapedPoster}\\[\\/img\\](?:\\[\\/url\\])?\\s*`, 'i'), '');
+                    }
+                    if (yemaPTInfos.pic_info) {
+                        const yemaPTScreenshotBBCodes = yemaPTInfos.pic_info.match(/(\[url=.*?\])?\[img\].*?\[\/img\](\[\/url\])?/ig) || [];
+                        yemaPTScreenshotBBCodes.forEach(function(item) {
+                            const escapedItem = item.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+                            cleaned = cleaned.replace(new RegExp(`\\s*${escapedItem}\\s*`, 'ig'), '\n');
+                        });
                     }
                     if (yemaPTMediaInfo.length > 20 && yemaPTMediaInfo.match(/DISC INFO|\.MPLS|Video Codec|Disc Label|General|RELEASE\.NAME|RELEASE DATE|Unique ID|RESOLUTiON|Bitrate|帧　率|音频码率|视频码率/i)) {
                         const normalizeMediaInfo = function(value) {
@@ -17622,6 +17642,7 @@ function auto_feed() {
             if (yemaPTMediaInfo) {
                 torrentForm?.setFieldsValue({ 'mediaInfo': yemaPTMediaInfo });
             }
+            fillYemaPTScreenshotList();
             torrentForm?.setFieldsValue({ 'categoryId': yemaPTOptionValue('categoryId', type_code, '未分类') });
             return true;
         }


### PR DESCRIPTION
## 变更内容

  - 为 YemaPT 发种页新增 `screenshotList` 自动填充。
  - 复用现有截图原图转换逻辑，支持将简介中的截图链接转换为原图 URL 后写入表单。
  - 填充截图列表后，从详细介绍 `longDesc` 中移除对应截图，避免截图重复出现在详细介绍和截图列表中。
  - 对截图 URL 做空值过滤和去重处理。

## 验证

  - 执行 `node --check auto_feed.user.js`，语法检查通过。